### PR TITLE
Feature/netcoreapp3 Migration to Asp.net core 3

### DIFF
--- a/GeekLearning.Domain.sln
+++ b/GeekLearning.Domain.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29411.108
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{FBAC4C17-D755-49A9-959D-18FD6B95B543}"
 EndProject

--- a/samples/GeekLearning.Domain.WebSamples/GeekLearning.Domain.WebSamples.csproj
+++ b/samples/GeekLearning.Domain.WebSamples/GeekLearning.Domain.WebSamples.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\GeekLearning.Domain\GeekLearning.Domain.csproj" />
     <ProjectReference Include="..\..\src\GeekLearning.Domain.AspnetCore\GeekLearning.Domain.AspnetCore.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/samples/GeekLearning.Domain.WebSamples/Startup.cs
+++ b/samples/GeekLearning.Domain.WebSamples/Startup.cs
@@ -6,11 +6,12 @@
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
 
     public class Startup
     {
-        public Startup(IHostingEnvironment env)
+        public Startup(IWebHostEnvironment env)
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
@@ -29,14 +30,17 @@
             services.AddMvc().AddDomain();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddScoped<SampleDomain>();
+            services.AddLogging(loggingBuilder =>
+            {
+                loggingBuilder.AddConfiguration(Configuration.GetSection("Logging"));
+                loggingBuilder.AddDebug().AddConsole();
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-
+            //loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -45,14 +49,13 @@
             {
                 app.UseExceptionHandler("/Home/Error");
             }
-
+            app.UseRouting();
             app.UseStaticFiles();
 
-            app.UseMvc(routes =>
+            app.UseEndpoints(endpoints =>
             {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                endpoints.MapRazorPages();
+                endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
             });
         }
     }

--- a/samples/GeekLearning.Domain.WebSamples/Startup.cs
+++ b/samples/GeekLearning.Domain.WebSamples/Startup.cs
@@ -40,7 +40,6 @@
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
-            //loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/samples/GeekLearning.Domain.WebSamples/web.config
+++ b/samples/GeekLearning.Domain.WebSamples/web.config
@@ -1,14 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-
   <!--
     Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
   -->
-
   <system.webServer>
     <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false">
+      <environmentVariables>
+        <environmentVariable name="COMPLUS_ForceENC" value="1" />
+        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+      </environmentVariables>
+    </aspNetCore>
   </system.webServer>
 </configuration>

--- a/src/GeekLearning.Domain.AspnetCore.Core/DomainExceptionFilter.cs
+++ b/src/GeekLearning.Domain.AspnetCore.Core/DomainExceptionFilter.cs
@@ -62,9 +62,11 @@
                typeof(Response<object>),
                result.Value);
 
-            var acceptableMediaTypes = MediaTypeHeaderValue.ParseList(context.HttpContext.Request.Headers[HeaderNames.Accept]).Where(mt => mt.Quality >= 0.8) //to discuss. The asp.net core technique rounds up to 1 too
-                .Where(mt => mt.MediaType.Value != "*/*")
-                .ToList();
+            //cf issue https://github.com/aspnet/AspNetCore/issues/15209 to parse request accept headers
+            var acceptableMediaTypes = MediaTypeHeaderValue.ParseList(context.HttpContext.Request.Headers[HeaderNames.Accept])
+                .Where(mt => mt.MediaType.Value != "*/*").ToList();
+            acceptableMediaTypes.ForEach(m => m.Quality ??= 1); //no specified quality means maximum
+            acceptableMediaTypes = acceptableMediaTypes.OrderByDescending(m => m.Quality).ToList();
 
             if (acceptableMediaTypes.Any())
             {

--- a/src/GeekLearning.Domain.AspnetCore.Core/GeekLearning.Domain.AspnetCore.Core.csproj
+++ b/src/GeekLearning.Domain.AspnetCore.Core/GeekLearning.Domain.AspnetCore.Core.csproj
@@ -4,23 +4,22 @@
     <Description>ASP.NET Core helper library to deal with a Domain layer.</Description>
     <VersionPrefix>0.0.1</VersionPrefix>
     <Authors>Geek Learning;Adrien Siffermann;Cyprien Autexier;Anna Yafi</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
     <PackageProjectUrl>https://github.com/geeklearningio/gl-dotnet-domain</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/geeklearningio/gl-dotnet-domain/blob/master/LICENSE.md</PackageLicenseUrl>
     <RootNamespace>GeekLearning.Domain.AspnetCore</RootNamespace>
   </PropertyGroup>
-
+ <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"></FrameworkReference>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GeekLearning.Domain.Primitives\GeekLearning.Domain.Primitives.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/GeekLearning.Domain.AspnetCore.Core/Properties/launchSettings.json
+++ b/src/GeekLearning.Domain.AspnetCore.Core/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:54815/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "GeekLearning.Domain.AspnetCore.Core": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:54816/"
+    }
+  }
+}

--- a/src/GeekLearning.Domain.AspnetCore.Core/libman.json
+++ b/src/GeekLearning.Domain.AspnetCore.Core/libman.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "defaultProvider": "cdnjs",
+  "libraries": []
+}

--- a/src/GeekLearning.Domain.AspnetCore/GeekLearning.Domain.AspnetCore.csproj
+++ b/src/GeekLearning.Domain.AspnetCore/GeekLearning.Domain.AspnetCore.csproj
@@ -4,7 +4,7 @@
     <Description>ASP.NET Core helper library to deal with a Domain layer.</Description>
     <VersionPrefix>0.0.1</VersionPrefix>
     <Authors>Geek Learning;Adrien Siffermann;Cyprien Autexier;Anna Yafi</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
     <PackageProjectUrl>https://github.com/geeklearningio/gl-dotnet-domain</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/geeklearningio/gl-dotnet-domain/blob/master/LICENSE.md</PackageLicenseUrl>
   </PropertyGroup>
@@ -15,11 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/GeekLearning.Domain.Tests/GeekLearning.Domain.Tests.csproj
+++ b/tests/GeekLearning.Domain.Tests/GeekLearning.Domain.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NB : Due to issue https://github.com/aspnet/AspNetCore/issues/4932,
they made lots of public types internal. So `AcceptHeaderParser.ParseAcceptHeader`, becomes completely unreachable with all submethods and subtypes.
Rather use the native` MediaTypeHeaderValue.ParseList` than copying in our project the `ParseAcceptHeader `class, made internal on purpose so that we don't use them. 
cf also https://github.com/aspnet/AspNetCore/issues/15209
#58 